### PR TITLE
Hardcoded wifi

### DIFF
--- a/kvstore_client.cpp
+++ b/kvstore_client.cpp
@@ -1,9 +1,6 @@
 
 #include <Arduino.h>
 
-#if 0
-#include "esp32/rom/rtc.h"
-#endif
 #include <HTTPClient.h>
 #include <WiFiClient.h>
 #include <WiFi.h>

--- a/nightscout_epd.ino
+++ b/nightscout_epd.ino
@@ -23,9 +23,10 @@ void print_time();
 #include <WiFi.h>
 #if USE_WIFIMANAGER
 #include <WiFiManager.h>
-
-WiFiManager wifiManager;
+#else
+typedef int WiFiManager;
 #endif
+WiFiManager wifiManager;  // unfortunately always needed :shrug:
 
 
 uint8_t mac[6];
@@ -56,7 +57,6 @@ int get_battery_mv() {
   return v;
 }
 
-// #if USE_WIFIMANAGER
 void configModeCallback (WiFiManager *myWiFiManager) {
 #if USE_WIFIMANAGER
 
@@ -116,12 +116,12 @@ uint8_t init_wifi() {
   // https://github.com/espressif/esp-idf/issues/2989#issuecomment-459941899
   // linked from
   // https://github.com/espressif/arduino-esp32/issues/3961#issuecomment-624740732
-  wifi_country_t country = {
-    .cc = "CN",
-    .schan = 1,
-    .nchan = 13,
-    .policy = WIFI_COUNTRY_POLICY_MANUAL,
-  };
+  // wifi_country_t country = {
+  //   .cc = "CN",
+  //   .schan = 1,
+  //   .nchan = 13,
+  //   .policy = WIFI_COUNTRY_POLICY_MANUAL,
+  // };
   // esp_wifi_start();
   Serial.println("Connecting to wifi...");
   Serial.print("SSID: ");

--- a/nightscout_epd.ino
+++ b/nightscout_epd.ino
@@ -50,13 +50,13 @@ void set_date_from_server_date_header(const char* date_header);
 int get_battery_mv() {
   // read slowly to avoid noise
   analogSetClockDiv(255);
-  //int v = analogRead(35);
   int v = analogReadMilliVolts(35);
   // raw millivolts is half of actual battery voltage. multiply by two to get actual voltage
   v = v * 2;
   return v;
 }
 
+// unfortunately this seems to always need to be defined :shrug:
 void configModeCallback (WiFiManager *myWiFiManager) {
 #if USE_WIFIMANAGER
 
@@ -80,9 +80,7 @@ void configModeCallback (WiFiManager *myWiFiManager) {
   sprintf(buf, "AP: %s", myWiFiManager->getConfigPortalSSID().c_str());
   fullscreen_message(buf);
 #endif
-
 }
-// #endif
 
 uint8_t init_wifi() {
   WiFi.macAddress(mac);
@@ -148,15 +146,11 @@ void xkcd_434() {
   WiFi.mode(WIFI_OFF);
   Serial.println("disabled");
 }
+
 void setup() {
-  // put your setup code here, to run once:
   Serial.begin(115200);
   Serial.println("Ready");
-#if TEST
-  delay(5000);
-#else
   delay(10);
-#endif
 
 #if ESP32
   Serial.println("CPU0 reset reason:");
@@ -169,19 +163,6 @@ void setup() {
 #endif
   print_time();
   delay(10);
-#if TEST
-Serial.println("display init");
-  display_init();
-  Serial.println("sleep");
-  sleep(1000);
-  Serial.println("display hibernate");
-  display_hibernate();
-  Serial.println("set sleep timer and deep sleep");
-          esp_sleep_enable_timer_wakeup(5*1000000);
-        esp_deep_sleep_start();
-        Serial.println("did not sleep");
-
-#endif
   preferences.begin("nightscout_epd", false);
 #if ESP32
   if (rtc_get_reset_reason(0) == 1) {
@@ -190,7 +171,7 @@ Serial.println("display init");
     fullscreen_message("Welcome:)");
   }
 #elif ESP32S3
-  Serial.println("Do be implemented");
+  Serial.println("To be implemented");
 #else
   Serial.println("Non-ESP32 not implemented");
 #endif
@@ -261,12 +242,6 @@ Serial.println("display init");
   } else {
     // wifi failed to connect. deep sleep for 1 minute.
     Serial.println("wifi failed to connect. deep sleep for 1 minute.");
-    // char buf[100];
-    // sprintf(buf, "Restarting...");
-    // HelloWorld = buf;
-    // helloWorld();
-    // delay(5000);
-    // ESP.restart();
     xkcd_434();
     esp_sleep_enable_timer_wakeup(60*1000000);
     esp_deep_sleep_start();

--- a/nightscout_epd.ino
+++ b/nightscout_epd.ino
@@ -4,7 +4,6 @@
 #include "nightscout.h"
 #include "arduino_secrets.h"
 #include "kvstore_client.h"
-#include "esp_wifi.h"
 
 extern const int FW_VERSION;
 
@@ -57,8 +56,7 @@ int get_battery_mv() {
   return v;
 }
 
-#if 0 //USE_WIFIMANAGER
-/*
+// #if USE_WIFIMANAGER
 void configModeCallback (WiFiManager *myWiFiManager) {
 #if USE_WIFIMANAGER
 
@@ -84,8 +82,7 @@ void configModeCallback (WiFiManager *myWiFiManager) {
 #endif
 
 }
-*/
-#endif
+// #endif
 
 uint8_t init_wifi() {
   WiFi.macAddress(mac);
@@ -125,10 +122,17 @@ uint8_t init_wifi() {
     .nchan = 13,
     .policy = WIFI_COUNTRY_POLICY_MANUAL,
   };
-  esp_wifi_start();
-  esp_wifi_set_country(&country);
+  // esp_wifi_start();
+  Serial.println("Connecting to wifi...");
+  Serial.print("SSID: ");
+  Serial.println(SECRET_WIFI_SSID);
+  Serial.print("PSK: ");
+  Serial.println(SECRET_WIFI_PSK);
+  WiFi.mode(WIFI_STA);
   WiFi.begin(SECRET_WIFI_SSID, SECRET_WIFI_PSK);
-  int retries = 15;
+  // esp_wifi_set_country(&country);
+
+  int retries = 35;
   while (WiFi.status() != WL_CONNECTED && retries > 0) {
     delay(500);
     Serial.print(".");

--- a/nightscout_epd.ino
+++ b/nightscout_epd.ino
@@ -106,7 +106,7 @@ uint8_t init_wifi() {
   //wifiManager.setConfigPortalTimeout(300);
   //return wifiManager.autoConnect();
   WiFi.begin(SECRET_WIFI_SSID, SECRET_WIFI_PSK);
-  int tries = 5;
+  int tries = 15;
   while (WiFi.status() != WL_CONNECTED) {
     delay(500);
     Serial.print(".");
@@ -164,6 +164,7 @@ Serial.println("display init");
   Serial.println("What type of chip is this");
 #endif
   if (init_wifi()) {
+    Serial.println("wifi connected. going to load data from nightscout");
     // char buf[100];
     // sprintf(buf, "%s", macAddr);
     // HelloWorld = buf;

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,7 @@ lib_deps =
 	; symlink://../thingsboard-client-sdk
 		#https://github.com/MathewHDYT/thingsboard-client-sdk.git
     bblanchon/ArduinoJson @ ^6.21.4
-    WiFiManager @ ^2.0.16-rc.2
+    https://github.com/tzapu/WiFiManager.git @ ^2.0.17
     #vshymanskyy/Preferences
     GxEPD2
 monitor_speed = 115200
@@ -25,18 +25,19 @@ board_build.partitions=min_spiffs.csv
 build_flags =
 	-DUSER_SETUP_LOADED
     -DTEST=0
-    -DUSE_WIFIMANAGER=0
+    -DUSE_WIFIMANAGER=1
 
 [env:epd_t5_213]
-platform = espressif32
+platform = https://github.com/platformio/platform-espressif32.git
+; platform_packages = framework-arduinoespressif32 @ https://github.com/espressif/arduino-esp32.git
 board = esp32dev
-build_flags = -D ESP32=1
+build_flags = ${env.build_flags} -D ESP32=1 -D CORE_DEBUG_LEVEL=4
 
 [env:epd_t5_47]
 platform = espressif32
 board = lilygo-t5-47-plus-v2
 # board = lilygo-t5-47
-build_flags = -D CORE_DEBUG_LEVEL=3 -D ESP32S3=1
+build_flags = ${env.build_flags} -D CORE_DEBUG_LEVEL=3 -D ESP32S3=1
 upload_port=/dev/ttyACM0
 
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,7 +25,7 @@ board_build.partitions=min_spiffs.csv
 build_flags =
 	-DUSER_SETUP_LOADED
     -DTEST=0
-    -DUSE_WIFIMANAGER=1
+    -DUSE_WIFIMANAGER=0
 
 [env:epd_t5_213]
 platform = https://github.com/platformio/platform-espressif32.git

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,16 +18,19 @@ lib_deps =
     GxEPD2
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
-upload_speed = 921600
+; upload_speed = 921600
+upload_speed = 115200
 board_build.partitions=min_spiffs.csv
 # upload.maximum_size=1966080
 build_flags =
 	-DUSER_SETUP_LOADED
+    -DUSE_WIFIMANAGER=0
 
 
 [env:epd_t5_213]
 platform = espressif32
 board = esp32dev
+build_flags = -D ESP32=1
 
 [env:epd_t5_47]
 platform = espressif32


### PR DESCRIPTION
Allow the option to use a hardcoded wifi rather than WiFiManager; for example, this is useful when connecting to a hidden network.